### PR TITLE
Update sphinx-book-theme to the latest version

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 title: Bio-image Analysis Notebooks
-author: Robert Haase, Guillaume Witz, Miguel Fernandes, Marcelo Leomil Zoccoler, Shannon Taylor, Mara Lampert, Till Korten & add-your-name-here-by-sending-a-pull-request-containing-a-notebook
+author: Robert Haase, Guillaume Witz, Miguel Fernandes, Marcelo Leomil Zoccoler, Shannon Taylor, Mara Lampert, Till Korten, Markus Ankenbrand & add-your-name-here-by-sending-a-pull-request-containing-a-notebook
 logo: logo.png
 
 # Execute notebooks if the have one missing output

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jupyter-book>=0.7.0b
-sphinx-book-theme<1.0.0
+sphinx-book-theme>=1.1.3
 matplotlib
 numpy


### PR DESCRIPTION
Requiring at least version 1.1.3, to make sure the search field stays in the navbar.